### PR TITLE
Polish public documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+This is a personal blog repository, so broad content contributions are not expected.
+
+Small corrections are welcome:
+
+- typo fixes
+- broken link fixes
+- formatting fixes
+- small clarifications that preserve the original meaning
+
+For larger content changes, please open an issue first and describe the problem before sending a pull request.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+# License
+
+Copyright (c) 2026 jackhai9
+
+Unless otherwise noted:
+
+- Blog posts, documentation, and other prose content are licensed under the Creative Commons Attribution 4.0 International License.
+- Automation scripts and repository maintenance code are licensed under the MIT License.
+
+## Creative Commons Attribution 4.0 International
+
+You may share and adapt the licensed prose content for any purpose, provided that you give appropriate credit, provide a link to the license, and indicate whether changes were made.
+
+Full license text: https://creativecommons.org/licenses/by/4.0/legalcode
+
+## MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the automation scripts and associated documentation files in this repository (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,71 +1,48 @@
-# 基于 Markdown + GitHub Pages
+# Markdown Blog
 
-完全以 Markdown 文件的形式来书写和组织博客。**现在要做的只是写 Markdown**，以前的[这种方式](https://github.com/jackhai9/jackhai9.github.io)就有点复杂了。
+<p align="center">
+  <a href="README.zh-CN.md">简体中文</a> | English
+</p>
 
-## 项目说明
+This repository contains a Markdown-first personal blog published with GitHub Pages. The main workflow is intentionally simple: write Markdown files, commit them to `main`, and let GitHub Pages render the site.
 
-- **[这里](https://jackhai9.github.io/blog/)就是通过此方式创建的博客。**
-- 仓库名可以任意起。
-- 只有一个main分支，用于存放 Markdown 文件。当然可以使用其他分支。
-- 手动开启这个仓库的 Github Pages 功能：Settings --> Pages --> 选择分支名并保存。
+Live site: [jackhai9.github.io/blog](https://jackhai9.github.io/blog/)
 
-- GitHub Pages 会优先把仓库根目录的 index.html 或 index.md 作为首页，如果没有这两个，就会以 README.md 作为首页。
+## What This Repository Is For
 
-  > 如果根目录下没有 index.html 文件，GitHub Pages 使用默认的 [Jekyll](https://github.com/jekyll/jekyll) 这样的静态站点生成器，把 index.md 或者 README.md 这样的 Markdown 文件转成 HTML ，用于浏览器渲染和显示。截止目前2024年1月，Markdown 文件还不是浏览器原生支持渲染的格式。
+- Keep blog posts as plain Markdown files.
+- Publish the repository directly through GitHub Pages.
+- Avoid the heavier Hexo workflow used by the older `jackhai9.github.io` repository.
+- Keep images, links, and article structure close to the source content.
 
-## 整体流程
+## Repository Layout
 
-1. 手动 -- 克隆仓库
-2. 手动 -- 本地写Markdown文件并自行控制文件之间的组织关系（链接引用、图片、目录等使用相对路径）
-3. 手动 -- 提交Markdown文件到GitHub
-4. 自动 -- Github Pages 会自动执行其内置的[workflow](https://github.com/jackhai9/blog/actions/workflows/pages/pages-build-deployment)最终部署到GitHub Pages
-5. 附加功能：执行 `bash scripts/setup-hooks.sh` 安装 git hooks，提交 Markdown 时会自动补写“本文创建日期 / 最后更新日期”
+- `index.md` is the blog entry page.
+- `src/` stores article Markdown files.
+- `_config.yml` configures the GitHub Pages/Jekyll site metadata.
+- `_includes/head-custom.html` customizes the generated HTML head.
+- `scripts/` contains local maintenance helpers for post metadata and migration.
+- `hooks/` contains Git hook templates used by `scripts/setup-hooks.sh`.
 
-## 概念说明
+## Writing Workflow
 
-- [Markdown](https://daringfireball.net/projects/markdown/)：一种易写易读的标记语言，通过解析器转为 XHTML (or HTML)。语法因不同的解析器或编辑器而异。
-- [GitHub Actions](https://docs.github.com/en/actions)：GitHub 提供的一种自动化工具，用于执行 workflow。
-- [workflow](https://docs.github.com/en/actions/using-workflows/about-workflows)：工作流，即 按希望的顺序排列组合一系列指令（action）。这些指令可以是各种任务，如安装依赖、测试代码、部署应用等。
-- [GitHub Pages](https://pages.github.com/)：GitHub 提供的一项服务，从 GitHub 仓库直接托管静态网站。常用于个人、项目或组织的网站，并且是免费的，不用再单独去申请域名，当然也支持指向你已申请的域名。很适合用来托管博客、项目文档、个人简历等。GitHub Pages 也默认使用 [Jekyll](https://github.com/jekyll/jekyll) 这样的静态站点生成器，直接把 Markdown 转成 HTML，见[我的另一个博客](https://github.com/jackhai9/blog)。在部署时会用到 GitHub Actions 提供的自动化构建和部署流程。总之，GitHub Pages为用户提供了一种简单便捷的方式，用于将代码和文档以网页的形式分享给他人。
+1. Create or edit Markdown files under `src/`.
+2. Use relative links for local articles and images.
+3. Commit the Markdown changes to `main`.
+4. GitHub Pages builds and publishes the site.
 
-## 其他说明
+Optional local hook setup:
 
-- **后续写博客只需要执行2、3就可以了。**
-
-- Markdown编辑器：推荐Typora。
-
-#### 配置SSH
-
-通过SSH与GitHub进行免密交互，无需每次访问都使用用户名和密码，设置方式：
-
-[检查本地现有的SSH密钥](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys)、[生成本地新的SSH密钥](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)、[添加本地SSH密钥到GitHub账户](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)。
-
-#### 添加favicon
-
-默认是没有favicon的，如果需要添加：
-
-1. 把你的favicon.ico放在根目录下，也就是跟index.md同一级目录。
-2. 新建_includes/head-custom.html，内容如下：把其中的"blog"替换成你自己的仓库名
-
-```html
-<link rel="shortcut icon" type="image/x-icon" href="/blog/favicon.ico">
+```bash
+bash scripts/setup-hooks.sh
 ```
 
-#### 修改默认博客名
+The hook updates article creation and last-updated metadata before commits.
 
-Jekyll 默认用仓库名作为博客名。如果不想使用默认的，则在根目录下创建`_config.yml`填入title即可，内容如下：
+## Legacy Blog
 
-```yaml
-title: 你的博客名
-description: 你的博客描述
-```
+The older Hexo-based blog lives in [`jackhai9/jackhai9.github.io`](https://github.com/jackhai9/jackhai9.github.io). This repository is the simpler Markdown-based successor.
 
+## License
 
-
-
-
----
-
-> 本文创建日期: 2024-01-28
->
-> 最后更新日期: 2026-06-13
+Unless otherwise noted, prose content is licensed under Creative Commons Attribution 4.0 International. Local automation scripts are available under the MIT terms described in [LICENSE](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,75 @@
+# 基于 Markdown + GitHub Pages
+
+<p align="center">
+  简体中文 | <a href="README.md">English</a>
+</p>
+
+完全以 Markdown 文件的形式来书写和组织博客。**现在要做的只是写 Markdown**，以前的[这种方式](https://github.com/jackhai9/jackhai9.github.io)就有点复杂了。
+
+## 项目说明
+
+- **[这里](https://jackhai9.github.io/blog/)就是通过此方式创建的博客。**
+- 仓库名可以任意起。
+- 只有一个main分支，用于存放 Markdown 文件。当然可以使用其他分支。
+- 手动开启这个仓库的 Github Pages 功能：Settings --> Pages --> 选择分支名并保存。
+
+- GitHub Pages 会优先把仓库根目录的 index.html 或 index.md 作为首页，如果没有这两个，就会以 README.md 作为首页。
+
+  > 如果根目录下没有 index.html 文件，GitHub Pages 使用默认的 [Jekyll](https://github.com/jekyll/jekyll) 这样的静态站点生成器，把 index.md 或者 README.md 这样的 Markdown 文件转成 HTML ，用于浏览器渲染和显示。截止目前2024年1月，Markdown 文件还不是浏览器原生支持渲染的格式。
+
+## 整体流程
+
+1. 手动 -- 克隆仓库
+2. 手动 -- 本地写Markdown文件并自行控制文件之间的组织关系（链接引用、图片、目录等使用相对路径）
+3. 手动 -- 提交Markdown文件到GitHub
+4. 自动 -- Github Pages 会自动执行其内置的[workflow](https://github.com/jackhai9/blog/actions/workflows/pages/pages-build-deployment)最终部署到GitHub Pages
+5. 附加功能：执行 `bash scripts/setup-hooks.sh` 安装 git hooks，提交 Markdown 时会自动补写“本文创建日期 / 最后更新日期”
+
+## 概念说明
+
+- [Markdown](https://daringfireball.net/projects/markdown/)：一种易写易读的标记语言，通过解析器转为 XHTML (or HTML)。语法因不同的解析器或编辑器而异。
+- [GitHub Actions](https://docs.github.com/en/actions)：GitHub 提供的一种自动化工具，用于执行 workflow。
+- [workflow](https://docs.github.com/en/actions/using-workflows/about-workflows)：工作流，即 按希望的顺序排列组合一系列指令（action）。这些指令可以是各种任务，如安装依赖、测试代码、部署应用等。
+- [GitHub Pages](https://pages.github.com/)：GitHub 提供的一项服务，从 GitHub 仓库直接托管静态网站。常用于个人、项目或组织的网站，并且是免费的，不用再单独去申请域名，当然也支持指向你已申请的域名。很适合用来托管博客、项目文档、个人简历等。GitHub Pages 也默认使用 [Jekyll](https://github.com/jekyll/jekyll) 这样的静态站点生成器，直接把 Markdown 转成 HTML，见[我的另一个博客](https://github.com/jackhai9/blog)。在部署时会用到 GitHub Actions 提供的自动化构建和部署流程。总之，GitHub Pages为用户提供了一种简单便捷的方式，用于将代码和文档以网页的形式分享给他人。
+
+## 其他说明
+
+- **后续写博客只需要执行2、3就可以了。**
+
+- Markdown编辑器：推荐Typora。
+
+#### 配置SSH
+
+通过SSH与GitHub进行免密交互，无需每次访问都使用用户名和密码，设置方式：
+
+[检查本地现有的SSH密钥](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys)、[生成本地新的SSH密钥](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)、[添加本地SSH密钥到GitHub账户](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)。
+
+#### 添加favicon
+
+默认是没有favicon的，如果需要添加：
+
+1. 把你的favicon.ico放在根目录下，也就是跟index.md同一级目录。
+2. 新建_includes/head-custom.html，内容如下：把其中的"blog"替换成你自己的仓库名
+
+```html
+<link rel="shortcut icon" type="image/x-icon" href="/blog/favicon.ico">
+```
+
+#### 修改默认博客名
+
+Jekyll 默认用仓库名作为博客名。如果不想使用默认的，则在根目录下创建`_config.yml`填入title即可，内容如下：
+
+```yaml
+title: 你的博客名
+description: 你的博客描述
+```
+
+
+
+
+
+---
+
+> 本文创建日期: 2024-01-28
+>
+> 最后更新日期: 2026-06-13


### PR DESCRIPTION
## Summary
- Make the public README default to English and keep the full Chinese version in `README.zh-CN.md`.
- Add a language switcher with the current language rendered as plain text.
- Add lightweight license and contribution guidance for a personal Markdown blog.

## Validation
- Ran `git diff --check`.
- Checked language switcher markup in both README files.
- Checked for unintended personal-name remnants.
- Updated repository description and topics.
