### PR TITLE
Harden theme setup and site metadata

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,10 +49,10 @@
 默认是没有favicon的，如果需要添加：
 
 1. 把你的favicon.ico放在根目录下，也就是跟index.md同一级目录。
-2. 新建_includes/head-custom.html，内容如下：把其中的"blog"替换成你自己的仓库名
+2. 新建_includes/head-custom.html，内容如下：
 
 ```html
-<link rel="shortcut icon" type="image/x-icon" href="/blog/favicon.ico">
+<link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}">
 ```
 
 #### 修改默认博客名

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 title: Jackhai的博客
 description: 记录技术与生活
+lang: zh-CN
 repo_url: https://github.com/jackhai9/blog
-

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,15 +1,39 @@
-<link rel="shortcut icon" type="image/x-icon" href="/blog/favicon.ico">
+<link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}">
 <meta name="color-scheme" content="light dark">
 
 <script>
 (function () {
   window.blogTheme = window.blogTheme || {};
+  window.blogTheme.storageKey = "blog-theme";
+
+  window.blogTheme.getStoredTheme = function () {
+    try {
+      return localStorage.getItem(window.blogTheme.storageKey);
+    } catch (error) {
+      return null;
+    }
+  };
+
+  window.blogTheme.setStoredTheme = function (theme) {
+    try {
+      localStorage.setItem(window.blogTheme.storageKey, theme);
+    } catch (error) {
+      return;
+    }
+  };
+
+  window.blogTheme.prefersDark = function () {
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+  };
 
   window.blogTheme.resolve = function () {
-    var savedTheme = localStorage.getItem("blog-theme");
-    var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    var savedTheme = window.blogTheme.getStoredTheme();
 
-    return savedTheme || (prefersDark ? "dark" : "light");
+    if (savedTheme === "dark" || savedTheme === "light") {
+      return savedTheme;
+    }
+
+    return window.blogTheme.prefersDark() ? "dark" : "light";
   };
 
   window.blogTheme.apply = function (theme) {
@@ -268,7 +292,7 @@ document.addEventListener("DOMContentLoaded", function () {
   button.addEventListener("click", function () {
     var nextTheme = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
     window.blogTheme.apply(nextTheme);
-    localStorage.setItem("blog-theme", nextTheme);
+    window.blogTheme.setStoredTheme(nextTheme);
     renderThemeToggle();
   });
 


### PR DESCRIPTION
## Summary
- Set the site language to zh-CN for generated GitHub Pages HTML.
- Use Jekyll relative_url for the favicon path instead of hardcoding /blog.
- Make the dark mode theme script tolerate unavailable localStorage or matchMedia.
- Update the Chinese README favicon example to match the runtime include.

## Validation
- git diff --cached --check
- node --check on scripts extracted from _includes/head-custom.html
- local script simulation for storage-disabled fallback and pageshow theme sync

Note: dev/build/start was not run per project instructions.