### PR TITLE
Remove default open source footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en-US' }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+{% seo %}
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    {% include head-custom.html %}
+  </head>
+  <body>
+    <div class="container-lg px-3 my-5 markdown-body">
+      {% if site.title and site.title != page.title %}
+      <h1><a href="{{ "/" | absolute_url }}">{{ site.title }}</a></h1>
+      {% endif %}
+
+      {{ content }}
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js" integrity="sha256-lZaRhKri35AyJSypXXs4o6OPFTbTmUoltBbDCbdzegg=" crossorigin="anonymous"></script>
+    <script>anchors.add();</script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add a local copy of the Primer default layout without the license-triggered open source footer.
- Keep the existing SEO tag, Primer stylesheet, head custom include, title header, content container, and AnchorJS behavior.

## Validation
- Static check confirms the local layout does not contain the footer text, github_edit_link, or Improve this page.
- Static check confirms head-custom include and anchors.add remain present.
- git diff --check
- node --check on scripts extracted from _includes/head-custom.html
- Markdown local link scan: missing_local_links 0

Note: dev/build/start was not run per project instructions.