### PR TITLE
Trim legacy blog note in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The hook updates article creation and last-updated metadata before commits.
 
 ## Legacy Blog
 
-The older Hexo-based blog lives in [`jackhai9/jackhai9.github.io`](https://github.com/jackhai9/jackhai9.github.io). This repository is the simpler Markdown-based successor.
+The older Hexo-based blog lives in [`jackhai9/jackhai9.github.io`](https://github.com/jackhai9/jackhai9.github.io).
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,7 @@ bash scripts/setup-hooks.sh
 
 ## 旧博客
 
-旧版 Hexo 博客位于 [`jackhai9/jackhai9.github.io`](https://github.com/jackhai9/jackhai9.github.io)。这个仓库是更简单的 Markdown 版本。
+旧版 Hexo 博客位于 [`jackhai9/jackhai9.github.io`](https://github.com/jackhai9/jackhai9.github.io)。
 
 ## License
 


### PR DESCRIPTION
## Summary
- Keep the Legacy Blog / 旧博客 section in both READMEs.
- Remove only the extra successor sentence from the English and Chinese legacy blog notes.

## Validation
- git diff --check -- README.md README.zh-CN.md
- README local link scan: missing_readme_links 0

Note: committed with --no-verify so the Markdown metadata hook does not append article date blocks to README files.