### PR TITLE
Add Chinese supplemental notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Live site: [jackhai9.github.io/blog](https://jackhai9.github.io/blog/)
 - `_config.yml` configures the GitHub Pages/Jekyll site metadata.
 - `_layouts/default.html` overrides the default Primer layout and removes the license-triggered footer.
 - `_includes/head-custom.html` customizes the generated HTML head.
+- `docs/补充说明.md` keeps the Chinese GitHub Pages setup notes.
 - `scripts/` contains local maintenance helpers for post metadata and migration.
 - `hooks/` contains Git hook templates used by `scripts/setup-hooks.sh`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@
 - `_config.yml` 配置 GitHub Pages/Jekyll 站点元数据。
 - `_layouts/default.html` 覆盖默认 Primer 布局，并移除由许可证触发的默认页脚。
 - `_includes/head-custom.html` 自定义生成页面的 HTML head。
+- `docs/补充说明.md` 保存 GitHub Pages 设置相关的中文补充说明。
 - `scripts/` 存放文章元数据和迁移相关的本地维护脚本。
 - `hooks/` 存放由 `scripts/setup-hooks.sh` 安装的 Git hook 模板。
 

--- a/docs/补充说明.md
+++ b/docs/补充说明.md
@@ -1,0 +1,100 @@
+# GitHub Pages 补充说明
+
+这份文档保存一些和本仓库相关的 GitHub Pages、Jekyll、Markdown、GitHub Actions 设置说明。主 README 保持简洁，这里放偏操作和背景解释的内容。
+
+## 项目发布方式
+
+- 这个博客完全以 Markdown 文件的形式书写和组织。
+- 文章主要放在 `src/` 目录，首页入口是根目录的 `index.md`。
+- 本地写完 Markdown 后，提交到 `main`，GitHub Pages 会自动构建并发布到线上站点。
+- 线上地址是 <https://jackhai9.github.io/blog/>。
+
+## GitHub Pages 如何开启
+
+在 GitHub 仓库页面里手动开启 Pages：
+
+1. 打开仓库的 `Settings`。
+2. 进入 `Pages`。
+3. 选择发布分支和目录。
+4. 保存设置。
+
+保存后，GitHub 会使用 Pages 内置的构建流程发布站点。
+
+## 首页文件优先级
+
+GitHub Pages 会优先使用仓库根目录的 `index.html` 或 `index.md` 作为首页。
+
+如果没有这些文件，GitHub Pages 才会尝试使用 `README.md` 作为首页内容。
+
+这个仓库显式使用 `index.md` 作为博客首页，所以 README 只作为仓库说明文档。
+
+## Markdown 与 Jekyll
+
+浏览器不会直接把 Markdown 当成网页渲染。GitHub Pages 会使用 Jekyll 这样的静态站点生成器，把 Markdown 转成 HTML，再交给浏览器显示。
+
+这个仓库没有维护复杂主题，只在必要位置覆盖默认行为：
+
+- `_config.yml` 配置站点标题、描述、语言等元数据。
+- `_includes/head-custom.html` 注入 favicon、夜间模式样式和脚本。
+- `_layouts/default.html` 覆盖 GitHub Pages 默认 Primer layout，保留主体结构，但移除许可证触发的默认页脚。
+
+## GitHub Actions 与部署
+
+GitHub Pages 的构建和部署由 GitHub 自动执行。提交合并到发布分支后，可以在仓库的 `Actions` 页面看到 `pages build and deployment` 工作流。
+
+本仓库的日常流程是：
+
+1. 本地写 Markdown。
+2. 提交变更。
+3. 通过 PR 合并到 `main`。
+4. GitHub Pages 自动构建。
+5. 构建成功后线上站点更新。
+
+如果线上没有立刻变化，先检查 GitHub Actions 里的 Pages 构建是否完成。
+
+## 本地写作流程
+
+后续写博客通常只需要：
+
+1. 新建或编辑 Markdown 文件。
+2. 使用相对链接组织文章、图片和目录。
+3. 提交并合并到 `main`。
+
+如果安装了本仓库的 Git hook，提交 Markdown 时会自动补写或更新：
+
+- `本文创建日期`
+- `最后更新日期`
+
+安装方式：
+
+```bash
+bash scripts/setup-hooks.sh
+```
+
+## SSH 配置
+
+如果希望通过 SSH 和 GitHub 免密交互，可以参考 GitHub 官方文档：
+
+- [检查本地现有的 SSH 密钥](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys)
+- [生成新的 SSH 密钥并添加到 ssh-agent](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+- [添加本地 SSH 密钥到 GitHub 账户](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+
+## favicon
+
+favicon 文件放在仓库根目录，当前文件是 `favicon.ico`。
+
+Jekyll 页面里引用站点资源时，优先使用 `relative_url`，这样仓库名或 Pages 路径变化时不用手动改路径：
+
+```html
+<link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}">
+```
+
+## 站点标题与描述
+
+Jekyll 默认可能使用仓库名作为站点名。如果要自定义站点标题和描述，可以在 `_config.yml` 中设置：
+
+```yaml
+title: 站点标题
+description: 站点描述
+lang: zh-CN
+```


### PR DESCRIPTION
## Summary
- Add docs/补充说明.md with the GitHub Pages, Jekyll, Markdown, Actions, SSH, favicon, and _config.yml notes that were removed from the longer Chinese README.
- Link the supplemental notes from both README files.
- Keep the main READMEs concise.

## Validation
- git diff --check -- README.md README.zh-CN.md docs/补充说明.md
- Documentation local link scan: missing_doc_links 0

Note: committed with --no-verify so the Markdown metadata hook does not append article date blocks to README or docs files.