### PR TITLE
Document commit hook and Pages workflow notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ bash scripts/setup-hooks.sh
 ```
 
 The hook updates article creation and last-updated metadata before commits.
+For README or docs-only commits, see [`docs/additional-notes.md`](docs/additional-notes.md#提交项目文档时的-hook-说明) before committing.
 
 ## Legacy Blog
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,6 +40,7 @@ bash scripts/setup-hooks.sh
 ```
 
 这个 hook 会在提交前更新文章的创建日期和最后更新日期。
+如果只提交 README 或 docs 这类项目文档，先看 [`docs/additional-notes.md`](docs/additional-notes.md#提交项目文档时的-hook-说明) 里的说明。
 
 ## 旧博客
 

--- a/docs/additional-notes.md
+++ b/docs/additional-notes.md
@@ -25,6 +25,29 @@
 4. 自动 -- Github Pages 会自动执行其内置的[workflow](https://github.com/jackhai9/blog/actions/workflows/pages/pages-build-deployment)最终部署到GitHub Pages
 5. 附加功能：执行 `bash scripts/setup-hooks.sh` 安装 git hooks，提交 Markdown 时会自动补写“本文创建日期 / 最后更新日期”
 
+### GitHub Pages workflow 提醒
+
+这个仓库当前没有自定义 `.github/workflows`，部署使用的是 GitHub Pages 内置的 `pages-build-deployment` workflow。
+
+如果 Actions 里出现 `Node.js 20 actions are deprecated` 这类 annotation，通常不是博客内容或 Jekyll 构建失败，而是 GitHub Actions 正在把 JavaScript action 的运行时从 Node.js 20 迁移到 Node.js 24。只要 Pages run 的最终状态是 `success`，这类 annotation 可以先不用处理。
+
+这个问题不能在当前仓库里通过“修改 action 版本号”直接解决，因为当前仓库没有可修改的 workflow YAML。理论上可以改成自定义 Pages workflow，并在里面手动指定新版 `actions/checkout`、`actions/upload-pages-artifact`、`actions/deploy-pages` 等版本；但这会让项目复杂不少。除非内置 Pages workflow 真的失败，否则这里保持 GitHub Pages 内置 workflow 更符合这个项目“简单写 Markdown”的目标。
+
+参考：GitHub Changelog - [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)。
+
+### 提交项目文档时的 hook 说明
+
+执行 `bash scripts/setup-hooks.sh` 后，本地 `pre-commit` hook 会对本次 staged 的所有 `.md` 文件运行 `scripts/autoappend-time.sh`。这对博客文章是有用的，但如果只是在改 `README.md`、`README.zh-CN.md` 或 `docs/` 里的项目说明文档，普通 `git commit` 也会自动追加“本文创建日期 / 最后更新日期”。
+
+只提交项目文档、且不希望追加文章时间块时，可以绕过本地 commit hook：
+
+```bash
+git add README.md README.zh-CN.md docs/additional-notes.md
+git commit --no-verify -m "Update project documentation"
+```
+
+`--no-verify` 的作用是跳过本地 commit hook。不要把它当成默认提交方式；写博客文章时仍然用普通 `git commit`，让 hook 自动维护文章日期。
+
 ## 概念说明
 
 - [Markdown](https://daringfireball.net/projects/markdown/)：一种易写易读的标记语言，通过解析器转为 XHTML (or HTML)。语法因不同的解析器或编辑器而异。


### PR DESCRIPTION
## Summary
- document when README/docs-only commits should use --no-verify
- explain the local pre-commit hook behavior that appends article date metadata
- document the GitHub Pages Node.js 20 deprecation annotation and why the built-in workflow can be left alone while it succeeds

## Verification
- git diff --check -- README.md README.zh-CN.md docs/additional-notes.md
- documentation link scan