### PR TITLE
Scope date metadata hook to blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Optional local hook setup:
 bash scripts/setup-hooks.sh
 ```
 
-The hook updates article creation and last-updated metadata before commits.
+The hook updates article creation and last-updated metadata for `index.md` and Markdown posts under `src/` before commits.
 
 ## Legacy Blog
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ bash scripts/setup-hooks.sh
 ```
 
 The hook updates article creation and last-updated metadata before commits.
-For README or docs-only commits, see [`docs/additional-notes.md`](docs/additional-notes.md#提交项目文档时的-hook-说明) before committing.
 
 ## Legacy Blog
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,7 +40,6 @@ bash scripts/setup-hooks.sh
 ```
 
 这个 hook 会在提交前更新文章的创建日期和最后更新日期。
-如果只提交 README 或 docs 这类项目文档，先看 [`docs/additional-notes.md`](docs/additional-notes.md#提交项目文档时的-hook-说明) 里的说明。
 
 ## 旧博客
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,7 +39,7 @@
 bash scripts/setup-hooks.sh
 ```
 
-这个 hook 会在提交前更新文章的创建日期和最后更新日期。
+这个 hook 会在提交前更新根目录 `index.md` 和 `src/` 目录下文章的创建日期和最后更新日期。
 
 ## 旧博客
 

--- a/docs/additional-notes.md
+++ b/docs/additional-notes.md
@@ -23,7 +23,7 @@
 2. 手动 -- 本地写Markdown文件并自行控制文件之间的组织关系（链接引用、图片、目录等使用相对路径）
 3. 手动 -- 提交Markdown文件到GitHub
 4. 自动 -- Github Pages 会自动执行其内置的[workflow](https://github.com/jackhai9/blog/actions/workflows/pages/pages-build-deployment)最终部署到GitHub Pages
-5. 附加功能：执行 `bash scripts/setup-hooks.sh` 安装 git hooks，提交 Markdown 时会自动补写“本文创建日期 / 最后更新日期”
+5. 附加功能：执行 `bash scripts/setup-hooks.sh` 安装 git hooks，提交根目录 `index.md` 或 `src/` 目录下的文章 Markdown 时会自动补写“本文创建日期 / 最后更新日期”；README 和 docs 等项目文档不会处理
 
 ## 概念说明
 

--- a/docs/additional-notes.md
+++ b/docs/additional-notes.md
@@ -25,19 +25,6 @@
 4. 自动 -- Github Pages 会自动执行其内置的[workflow](https://github.com/jackhai9/blog/actions/workflows/pages/pages-build-deployment)最终部署到GitHub Pages
 5. 附加功能：执行 `bash scripts/setup-hooks.sh` 安装 git hooks，提交 Markdown 时会自动补写“本文创建日期 / 最后更新日期”
 
-### 提交项目文档时的 hook 说明
-
-执行 `bash scripts/setup-hooks.sh` 后，本地 `pre-commit` hook 会对本次 staged 的所有 `.md` 文件运行 `scripts/autoappend-time.sh`。这对博客文章是有用的，但如果只是在改 `README.md`、`README.zh-CN.md` 或 `docs/` 里的项目说明文档，普通 `git commit` 也会自动追加“本文创建日期 / 最后更新日期”。
-
-只提交项目文档、且不希望追加文章时间块时，可以绕过本地 commit hook：
-
-```bash
-git add README.md README.zh-CN.md docs/additional-notes.md
-git commit --no-verify -m "Update project documentation"
-```
-
-`--no-verify` 的作用是跳过本地 commit hook。不要把它当成默认提交方式；写博客文章时仍然用普通 `git commit`，让 hook 自动维护文章日期。
-
 ## 概念说明
 
 - [Markdown](https://daringfireball.net/projects/markdown/)：一种易写易读的标记语言，通过解析器转为 XHTML (or HTML)。语法因不同的解析器或编辑器而异。

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,7 +5,7 @@
 # 项目根目录的相对路径
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
-# 遍历每个已暂存的 Markdown 文件，只为 src/ 下的博客文章维护时间信息
+# 遍历每个已暂存的 Markdown 文件，只为首页和 src/ 下的博客文章维护时间信息
 IFS=$'\n'
 git diff --name-only --cached | grep '\.md$' | while read -r FILE; do
   # 去除文件路径中的双引号
@@ -13,7 +13,7 @@ git diff --name-only --cached | grep '\.md$' | while read -r FILE; do
   # 将转义字符转换回原始字符，以防git没有设置"git config --global core.quotepath false"
   DECODED_FILE=$(printf "%b" "$CLEANED_FILE")
   case "$DECODED_FILE" in
-    src/*.md|src/**/*.md)
+    index.md|src/*.md|src/**/*.md)
       "$PROJECT_ROOT/scripts/autoappend-time.sh" "$DECODED_FILE"
       git add "$DECODED_FILE"
       ;;

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,16 +5,18 @@
 # 项目根目录的相对路径
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
-# 遍历每个Markdown文件
+# 遍历每个已暂存的 Markdown 文件，只为 src/ 下的博客文章维护时间信息
 IFS=$'\n'
 git diff --name-only --cached | grep '\.md$' | while read -r FILE; do
   # 去除文件路径中的双引号
   CLEANED_FILE=$(echo "$FILE" | sed 's/^"//' | sed 's/"$//')
   # 将转义字符转换回原始字符，以防git没有设置"git config --global core.quotepath false"
   DECODED_FILE=$(printf "%b" "$CLEANED_FILE")
-  # echo "Adding file: $DECODED_FILE"
-  "$PROJECT_ROOT/scripts/autoappend-time.sh" "$DECODED_FILE"
-  git add "$DECODED_FILE"
+  case "$DECODED_FILE" in
+    src/*.md|src/**/*.md)
+      "$PROJECT_ROOT/scripts/autoappend-time.sh" "$DECODED_FILE"
+      git add "$DECODED_FILE"
+      ;;
+  esac
 done
 unset IFS
-


### PR DESCRIPTION
## Summary
- limit the pre-commit date metadata hook to Markdown posts under src/
- remove README/docs guidance about using --no-verify
- keep normal commits safe for project documentation changes

## Verification
- node pre-commit src-scope assertion
- bash -n hooks/pre-commit scripts/setup-hooks.sh scripts/autoappend-time.sh
- shell path matching check for README/docs vs src posts
- git diff --check -- hooks/pre-commit README.md README.zh-CN.md docs/additional-notes.md
- documentation link scan
- installed hook matches template
- manual .git/hooks/pre-commit run after staging README/docs
- normal git commit without --no-verify