### PR TITLE
Reset legacy theme preference

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,6 +1,15 @@
 (function () {
   window.blogTheme = window.blogTheme || {};
-  window.blogTheme.storageKey = "blog-theme";
+  window.blogTheme.legacyStorageKey = "blog-theme";
+  window.blogTheme.storageKey = "blog-theme-override";
+
+  window.blogTheme.clearLegacyStoredTheme = function () {
+    try {
+      localStorage.removeItem(window.blogTheme.legacyStorageKey);
+    } catch (error) {
+      return;
+    }
+  };
 
   window.blogTheme.getStoredTheme = function () {
     try {
@@ -36,6 +45,7 @@
     document.documentElement.dataset.theme = theme || window.blogTheme.resolve();
   };
 
+  window.blogTheme.clearLegacyStoredTheme();
   window.blogTheme.apply();
 })();
 


### PR DESCRIPTION
## Summary
- ignore and clear the old blog-theme localStorage value so legacy saved light mode no longer blocks system dark mode
- keep manual theme persistence under a new storage key

## Verification
- node --check assets/js/theme.js
- regression check for legacy blog-theme=light with system dark
- manual override check with blog-theme-override
- theme button behavior check
- git diff --check -- assets/js/theme.js